### PR TITLE
Lists would not render correctly if T was of type IEnumerable<U>

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,6 +58,6 @@ jobs:
     - name: Display Version
       run: "echo SemVer: $GITVERSION_SEMVER"
     - name: Pack 
-      run: dotnet pack -o . -c Release /p:Version=0.0.1
+      run: dotnet pack -o . -c Release /p:Version=0.0.2
     - name: Publish
       run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json

--- a/MarkdownDocumentBuilder.Test.Unit/Builders/MarkdownDocumentBuilderTests.cs
+++ b/MarkdownDocumentBuilder.Test.Unit/Builders/MarkdownDocumentBuilderTests.cs
@@ -45,9 +45,11 @@ public class MarkdownDocumentBuilderTests
 
                 content.AddParagraph("Rick Astley's hit song where he sings about:");
 
-                content.AddOrderedList(
+                content.AddOrderedList(new string[]
+                {
                     "Never giving you up.",
-                    "Never letting you down.");
+                    "Never letting you down."
+                });
 
                 content.AddBlockquote("NOTE: He will also never run around and desert you!");
 

--- a/MarkdownDocumentBuilder.Test.Unit/Model/Elements/Lists/OrderedListTests.cs
+++ b/MarkdownDocumentBuilder.Test.Unit/Model/Elements/Lists/OrderedListTests.cs
@@ -9,10 +9,64 @@ namespace MarkdownDocumentBuilder.Test.Unit.Model.Elements.Lists;
 public class OrderedListTests
 {
     [TestMethod]
-    public void ToMarkdown_SimpleList_ReturnsExpectedMarkdown()
+    public void ToMarkdown_SimpleArray_ReturnsExpectedMarkdown()
     {
         // Arrange
         var simpleList = new string[] { "FirstItem", "SecondItem" };
+
+        var document = MarkdownDocument.Build(document =>
+        {
+            document.Content(content =>
+            {
+                content.AddOrderedList(simpleList);
+            });
+        });
+
+        using var stream = new MemoryStream();
+
+        // Act
+        document.SaveAsync(stream);
+
+        // Assert
+        string result = stream.ReadAsString();
+        string filePath = Path.Combine("Resources/List", "ExpectedSimpleList.md");
+        var expectedDocument = FileReader.ReadFile(filePath);
+        result.Should().Be(expectedDocument);
+    }
+
+    [TestMethod]
+    public void ToMarkdown_SimpleList_ReturnsExpectedMarkdown()
+    {
+        // Arrange
+        var simpleList = new List<string> { "FirstItem", "SecondItem" };
+
+        var document = MarkdownDocument.Build(document =>
+        {
+            document.Content(content =>
+            {
+                content.AddOrderedList(simpleList);
+            });
+        });
+
+        using var stream = new MemoryStream();
+
+        // Act
+        document.SaveAsync(stream);
+
+        // Assert
+        string result = stream.ReadAsString();
+        string filePath = Path.Combine("Resources/List", "ExpectedSimpleList.md");
+        var expectedDocument = FileReader.ReadFile(filePath);
+        result.Should().Be(expectedDocument);
+    }
+
+    [TestMethod]
+    public void ToMarkdown_SimpleEnumerable_ReturnsExpectedMarkdown()
+    {
+        // Arrange
+        var simpleList = Enumerable.Empty<string>();
+        simpleList = simpleList.Append("FirstItem");
+        simpleList = simpleList.Append("SecondItem");
 
         var document = MarkdownDocument.Build(document =>
         {
@@ -56,32 +110,6 @@ public class OrderedListTests
         // Assert
         string result = stream.ReadAsString();
         string filePath = Path.Combine("Resources/List", "ExpectedComplexList.md");
-        var expectedDocument = FileReader.ReadFile(filePath);
-        result.Should().Be(expectedDocument);
-    }
-
-    [TestMethod]
-    public void ToMarkdown_TwoComplexLists_ReturnsExpectedMarkdown()
-    {
-        // Arrange
-        var complexList = CreateComplexList();
-
-        var document = MarkdownDocument.Build(document =>
-        {
-            document.Content(content =>
-            {
-                content.AddOrderedList(complexList, complexList);
-            });
-        });
-
-        using var stream = new MemoryStream();
-
-        // Act
-        document.SaveAsync(stream);
-
-        // Assert
-        string result = stream.ReadAsString();
-        string filePath = Path.Combine("Resources/List", "ExpectedDoubleComplexList.md");
         var expectedDocument = FileReader.ReadFile(filePath);
         result.Should().Be(expectedDocument);
     }

--- a/MarkdownDocumentBuilder.Test.Unit/TestModel/ComplexList.cs
+++ b/MarkdownDocumentBuilder.Test.Unit/TestModel/ComplexList.cs
@@ -1,6 +1,8 @@
-﻿namespace MarkdownDocumentBuilder.Test.Unit.TestModel;
+﻿using MarkdownDocumentBuilder.Abstractions;
 
-internal class ComplexList
+namespace MarkdownDocumentBuilder.Test.Unit.TestModel;
+
+internal class ComplexList : IListRepresentation
 {
     public string FirstItem { get; set; }
     public NestedObject NestedObject { get; set; }

--- a/MarkdownDocumentBuilder/Abstractions/IListRepresentation.cs
+++ b/MarkdownDocumentBuilder/Abstractions/IListRepresentation.cs
@@ -1,0 +1,5 @@
+﻿namespace MarkdownDocumentBuilder.Abstractions;
+
+public interface IListRepresentation
+{
+}

--- a/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
@@ -42,16 +42,31 @@ public interface IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
+    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <returns><see cref="IMarkdownContentBuilder"/></returns>
+
+    IMarkdownContentBuilder AddOrderedList<T>(T classRepresentation);
+
+    /// <summary>
+    /// Adds an ordered list to the document
+    /// </summary>
     /// <param name="orderedListItems">The items in the ordered list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    IMarkdownContentBuilder AddOrderedList<T>(params T[] orderedListItems);
+    IMarkdownContentBuilder AddOrderedList<T>(IEnumerable<T> orderedListItems);
 
     /// <summary>
     /// Adds an unordered list to the document
     /// </summary>
     /// <param name="unorderedListItems">The items in the unordered list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    IMarkdownContentBuilder AddUnorderedList<T>(params T[] unorderedListItems);
+    IMarkdownContentBuilder AddUnorderedList<T>(IEnumerable<T> unorderedListItems);
+
+    /// <summary>
+    /// Adds an ordered list to the document
+    /// </summary>
+    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <returns><see cref="IMarkdownContentBuilder"/></returns>
+    IMarkdownContentBuilder AddUnorderedList<T>(T classRepresentation);
 
     /// <summary>
     /// Adds a table to the document

--- a/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
@@ -1,4 +1,5 @@
-﻿using MarkdownDocumentBuilder.Model.Document;
+﻿using MarkdownDocumentBuilder.Abstractions;
+using MarkdownDocumentBuilder.Model.Document;
 
 namespace MarkdownDocumentBuilder.Builders;
 
@@ -45,7 +46,7 @@ public interface IMarkdownContentBuilder
     /// <param name="classRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
 
-    IMarkdownContentBuilder AddOrderedList<T>(T classRepresentation);
+    IMarkdownContentBuilder AddOrderedList(IListRepresentation classRepresentation);
 
     /// <summary>
     /// Adds an ordered list to the document

--- a/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/IMarkdownContentBuilder.cs
@@ -43,10 +43,10 @@ public interface IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
-    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <param name="listRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
 
-    IMarkdownContentBuilder AddOrderedList(IListRepresentation classRepresentation);
+    IMarkdownContentBuilder AddOrderedList(IListRepresentation listRepresentation);
 
     /// <summary>
     /// Adds an ordered list to the document
@@ -65,9 +65,9 @@ public interface IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
-    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <param name="listRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    IMarkdownContentBuilder AddUnorderedList<T>(T classRepresentation);
+    IMarkdownContentBuilder AddUnorderedList<T>(T listRepresentation);
 
     /// <summary>
     /// Adds a table to the document

--- a/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
@@ -1,4 +1,6 @@
-﻿using MarkdownDocumentBuilder.Model.Document;
+﻿using MarkdownDocumentBuilder.Exceptions;
+using MarkdownDocumentBuilder.Extensions;
+using MarkdownDocumentBuilder.Model.Document;
 using MarkdownDocumentBuilder.Model.Document.Options;
 using MarkdownDocumentBuilder.Model.Elements;
 using MarkdownDocumentBuilder.Model.Elements.Headers;
@@ -85,9 +87,21 @@ public class MdContentBuilder : IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
+    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <returns><see cref="IMarkdownContentBuilder"/></returns>
+    public IMarkdownContentBuilder AddOrderedList<T>(T classRepresentation)
+    {
+        _ = classRepresentation ?? throw new ArgumentNullException(nameof(classRepresentation));
+        _markdownContent.AddElement(new OrderedList<T>(classRepresentation));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an ordered list to the document
+    /// </summary>
     /// <param name="orderedListItems">The items in the ordered list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    public IMarkdownContentBuilder AddOrderedList<T>(params T[] orderedListItems)
+    public IMarkdownContentBuilder AddOrderedList<T>(IEnumerable<T> orderedListItems)
     {
         _ = orderedListItems ?? throw new ArgumentNullException(nameof(orderedListItems));
 
@@ -101,11 +115,23 @@ public class MdContentBuilder : IMarkdownContentBuilder
     }
 
     /// <summary>
-    /// Adds an unordered list to the document
+    /// Adds an ordered list to the document
     /// </summary>
-    /// <param name="unorderedListItems">The items in the unordered list</param>
+    /// <param name="classRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    public IMarkdownContentBuilder AddUnorderedList<T>(params T[] unorderedListItems)
+    public IMarkdownContentBuilder AddUnorderedList<T>(T classRepresentation)
+    {
+        _ = classRepresentation ?? throw new ArgumentNullException(nameof(classRepresentation));
+        _markdownContent.AddElement(new UnorderedList<T>(classRepresentation));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an ordered list to the document
+    /// </summary>
+    /// <param name="orderedListItems">The items in the ordered list</param>
+    /// <returns><see cref="IMarkdownContentBuilder"/></returns>
+    public IMarkdownContentBuilder AddUnorderedList<T>(IEnumerable<T> unorderedListItems)
     {
         _ = unorderedListItems ?? throw new ArgumentNullException(nameof(unorderedListItems));
 

--- a/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
@@ -88,12 +88,12 @@ public class MdContentBuilder : IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
-    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <param name="listRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    public IMarkdownContentBuilder AddOrderedList(IListRepresentation classRepresentation)
+    public IMarkdownContentBuilder AddOrderedList(IListRepresentation listRepresentation)
     {
-        _ = classRepresentation ?? throw new ArgumentNullException(nameof(classRepresentation));
-        _markdownContent.AddElement(new OrderedList<IListRepresentation>(classRepresentation));
+        _ = listRepresentation ?? throw new ArgumentNullException(nameof(listRepresentation));
+        _markdownContent.AddElement(new OrderedList<IListRepresentation>(listRepresentation));
         return this;
     }
 
@@ -118,12 +118,12 @@ public class MdContentBuilder : IMarkdownContentBuilder
     /// <summary>
     /// Adds an ordered list to the document
     /// </summary>
-    /// <param name="classRepresentation">The class representation of the list</param>
+    /// <param name="listRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    public IMarkdownContentBuilder AddUnorderedList<T>(T classRepresentation)
+    public IMarkdownContentBuilder AddUnorderedList<T>(T listRepresentation)
     {
-        _ = classRepresentation ?? throw new ArgumentNullException(nameof(classRepresentation));
-        _markdownContent.AddElement(new UnorderedList<T>(classRepresentation));
+        _ = listRepresentation ?? throw new ArgumentNullException(nameof(listRepresentation));
+        _markdownContent.AddElement(new UnorderedList<T>(listRepresentation));
         return this;
     }
 

--- a/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
+++ b/MarkdownDocumentBuilder/Builders/MdContentBuilder.cs
@@ -1,4 +1,5 @@
-﻿using MarkdownDocumentBuilder.Exceptions;
+﻿using MarkdownDocumentBuilder.Abstractions;
+using MarkdownDocumentBuilder.Exceptions;
 using MarkdownDocumentBuilder.Extensions;
 using MarkdownDocumentBuilder.Model.Document;
 using MarkdownDocumentBuilder.Model.Document.Options;
@@ -89,10 +90,10 @@ public class MdContentBuilder : IMarkdownContentBuilder
     /// </summary>
     /// <param name="classRepresentation">The class representation of the list</param>
     /// <returns><see cref="IMarkdownContentBuilder"/></returns>
-    public IMarkdownContentBuilder AddOrderedList<T>(T classRepresentation)
+    public IMarkdownContentBuilder AddOrderedList(IListRepresentation classRepresentation)
     {
         _ = classRepresentation ?? throw new ArgumentNullException(nameof(classRepresentation));
-        _markdownContent.AddElement(new OrderedList<T>(classRepresentation));
+        _markdownContent.AddElement(new OrderedList<IListRepresentation>(classRepresentation));
         return this;
     }
 

--- a/MarkdownDocumentBuilder/Exceptions/MarkdownDocumentBuilderErrorCode.cs
+++ b/MarkdownDocumentBuilder/Exceptions/MarkdownDocumentBuilderErrorCode.cs
@@ -7,6 +7,6 @@
         CouldNotFindTableRowAtIndex,
         ProvidedEnumerableIsEmpty,
         ProvidedGenericTypeForTableDoesNotEqualRunTimeType,
-        CouldNotConvertToMarkdown
+        CouldNotConvertToMarkdown,
     }
 }

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/MarkdownList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/MarkdownList.cs
@@ -1,5 +1,5 @@
-﻿using System.Text;
-using MarkdownDocumentBuilder.Model.Document;
+﻿using MarkdownDocumentBuilder.Model.Document;
+using System.Text;
 
 namespace MarkdownDocumentBuilder.Model.Elements.Lists;
 
@@ -10,19 +10,10 @@ internal abstract class MarkdownList<TValue> : IMarkdownElement
     private readonly NestedIndex _nestedIndex;
 
     protected MarkdownList(
-        IBulletPointProvider bulletPointProvider,
-        params TValue[] value)
-    {
-        _value = value;
-        _bulletPointProvider = bulletPointProvider;
-        _nestedIndex = new NestedIndex();
-    }
-
-    protected MarkdownList(
        IBulletPointProvider bulletPointProvider,
        IEnumerable<TValue> value)
     {
-        _value = (IEnumerable<TValue>) value.ToArray();
+        _value = value;
         _bulletPointProvider = bulletPointProvider;
         _nestedIndex = new NestedIndex();
     }
@@ -101,8 +92,8 @@ internal abstract class MarkdownList<TValue> : IMarkdownElement
     }
 
     private void RecursivelyTraversePropertyUntilCanBeRenderedWithToString(
-        int indentationLevel, 
-        List<MarkdownLine> markdownLines, 
+        int indentationLevel,
+        List<MarkdownLine> markdownLines,
         object propertyValue)
     {
         if (propertyValue is null)

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/MarkdownList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/MarkdownList.cs
@@ -2,6 +2,7 @@
 using MarkdownDocumentBuilder.Model.Document;
 
 namespace MarkdownDocumentBuilder.Model.Elements.Lists;
+
 internal abstract class MarkdownList<TValue> : IMarkdownElement
 {
     protected IEnumerable<TValue> _value;
@@ -13,6 +14,15 @@ internal abstract class MarkdownList<TValue> : IMarkdownElement
         params TValue[] value)
     {
         _value = value;
+        _bulletPointProvider = bulletPointProvider;
+        _nestedIndex = new NestedIndex();
+    }
+
+    protected MarkdownList(
+       IBulletPointProvider bulletPointProvider,
+       IEnumerable<TValue> value)
+    {
+        _value = (IEnumerable<TValue>) value.ToArray();
         _bulletPointProvider = bulletPointProvider;
         _nestedIndex = new NestedIndex();
     }
@@ -168,4 +178,10 @@ internal abstract class MarkdownList<TValue> : IMarkdownElement
 
     private static bool ShouldBeRenderedWithToString(object item, Type itemType)
         => itemType.IsValueType || item is string;
+
+    private static bool IsListType<T>()
+    {
+        Type type = typeof(T);
+        return (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>));
+    }
 }

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/OrderedList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/OrderedList.cs
@@ -5,4 +5,8 @@ internal class OrderedList<TValue> : MarkdownList<TValue>
     public OrderedList(params TValue[] value) : base(new OrderedBulletPointProvider(), value)
     {
     }
+
+    public OrderedList(IEnumerable<TValue> value) : base(new OrderedBulletPointProvider(), value)
+    {
+    }
 }

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/OrderedList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/OrderedList.cs
@@ -1,8 +1,10 @@
-﻿namespace MarkdownDocumentBuilder.Model.Elements.Lists;
+﻿using MarkdownDocumentBuilder.Extensions;
+
+namespace MarkdownDocumentBuilder.Model.Elements.Lists;
 
 internal class OrderedList<TValue> : MarkdownList<TValue>
 {
-    public OrderedList(params TValue[] value) : base(new OrderedBulletPointProvider(), value)
+    public OrderedList(TValue value) : base(new OrderedBulletPointProvider(), value.WrapAsEnumerable())
     {
     }
 

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/UnorderedList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/UnorderedList.cs
@@ -2,7 +2,11 @@
 
 internal class UnorderedList<TValue> : MarkdownList<TValue>
 {
-    public UnorderedList(params TValue[] value) : base(new UnorderedBulletPointProvider(), value)
+    public UnorderedList(params TValue[] value) : base(new OrderedBulletPointProvider(), value)
+    {
+    }
+
+    public UnorderedList(IEnumerable<TValue> value) : base(new OrderedBulletPointProvider(), value)
     {
     }
 }

--- a/MarkdownDocumentBuilder/Model/Elements/Lists/UnorderedList.cs
+++ b/MarkdownDocumentBuilder/Model/Elements/Lists/UnorderedList.cs
@@ -1,8 +1,10 @@
-﻿namespace MarkdownDocumentBuilder.Model.Elements.Lists;
+﻿using MarkdownDocumentBuilder.Extensions;
+
+namespace MarkdownDocumentBuilder.Model.Elements.Lists;
 
 internal class UnorderedList<TValue> : MarkdownList<TValue>
 {
-    public UnorderedList(params TValue[] value) : base(new OrderedBulletPointProvider(), value)
+    public UnorderedList(TValue value) : base(new OrderedBulletPointProvider(), value.WrapAsEnumerable())
     {
     }
 


### PR DESCRIPTION
the params T[] would behave in unexpected ways when T was of type IEnumerable<U>. Looked at multiple solutions that would make the use of params T[] very complex. The easier solution was to create two methods, one that forces a single Enumerable, and another for class representations.

Thinking of dropping generic enumerable support altogether in favor of only allowing enumerables of type string. Since nested enumerables give all sorts of problems as well. Considered throwing a NotSupportedException on Lists, but what about other weird types such as Dictionary<T> or whatever? This is becoming way too complex.

Ofcourse the method taking T as an object can still take classes who have nested enumerables as a property on them, which for which rendering would get attempted.

I'd rather stay away from something like:

```
public interface IListRepresentation
{
  IEnumerable<IListItem> GetListItems();
}

public interface IListItem
{
  string GetValue();
  string IEnumerable<ListItem> GetSubListItems
}
```

as this would require a decent amount of mapping in order to create a markdownlist. But I almost see no other way of implementing this. I guess this is the downside of using reflection.

The Table class does not suffer from these problems as it just uses toString() to render it's lines. If you want to place an enumerable in there you get a weird table, but that's expected.

Another option could be to expose a TableBuilder. Something like:

```
var document = MarkdownDocument.Build(document =>
        {
            document.Content(content =>
            {
                content.AddOrderedList(list =>
               {
                  list.AddItem(item => 
                  {
                    item.AddSubItem(subItem => subItem.Value = "test");
                  });
               });
            });
        });
```

but this is also quite verbose.